### PR TITLE
Add sonar scanner to git hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 **/__pycache__/**
 **/.scannerwork/**
+**/.pytest_cache/**
 **/.python-version
 **/htmlcov/**
 **/coverage/**

--- a/backend/.pre-commit-config.yaml
+++ b/backend/.pre-commit-config.yaml
@@ -31,3 +31,8 @@ repos:
       - pytest-cov
       - pytest-mock
     language: python
+  - id: sonar
+    name: sonar-scanner
+    stages: [push]
+    entry: bash -c "docker-compose run --no-TTY sonar-scanner-cloud"
+    language: system


### PR DESCRIPTION
This is probably temporary until I get Github Actions set up, but I just wanted to get SonarCloud running. For now, it will run as a pre-push git hook.