### PR TITLE
Omit files in tests/ for coverage

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -23,3 +23,8 @@ pytest-mock = "^3.11.1"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.coverage.run]
+omit = [
+    "tests/*"
+]


### PR DESCRIPTION
Add configuration in pyproject.toml to not measure `tests/` folder for code coverage 