### PR TITLE
Add workflows config file for sonar-scanner

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,22 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  sonarcloud:
+    name: SonarCloud
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,6 +8,17 @@ on:
     types: [opened, synchronize, reopened]
 
 jobs:
+  unit-test:
+    name: pytest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: pytest unit test run
+        run: |
+          bash -c backend/bin/test
+
   sonarcloud:
     name: SonarCloud
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,7 +53,11 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: test-coverage-report
-          path: backend/coverage/coverage.xml
+          path: backend/coverage/
+
+      - name: Normalize source path in test report
+        run: |
+          sed -i "s/<source>.*\/app/<source>\/github\/workspace/g" backend/coverage/coverage.xml
 
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,9 +15,24 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: pytest unit test run
+
+      - name: Update environment
         run: |
-          bash -c backend/bin/test
+          sudo add-apt-repository ppa:deadsnakes/ppa
+          sudo apt-get update -y
+          sudo apt-get install python3.11
+          sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+
+      - name: Install dependencies
+        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+        run: bash -c "cd backend && poetry install --no-interaction --no-root"
+
+      - name: Run pytest unit tests
+        run: |
+          bash -c "cd backend && poetry run bin/test"
 
   sonarcloud:
     name: SonarCloud

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,13 +34,27 @@ jobs:
         run: |
           bash -c "cd backend && poetry run bin/test"
 
+      - name: Upload pytest test report
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-coverage-report
+          path: backend/coverage/coverage.xml
+
   sonarcloud:
     name: SonarCloud
+    needs: unit-test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+
+      - name: Download pytest test report
+        uses: actions/download-artifact@v3
+        with:
+          name: test-coverage-report
+          path: backend/coverage/coverage.xml
+
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master
         env:

--- a/backend/.pre-commit-config.yaml
+++ b/backend/.pre-commit-config.yaml
@@ -31,8 +31,3 @@ repos:
       - pytest-cov
       - pytest-mock
     language: python
-  - id: sonar
-    name: sonar-scanner
-    stages: [push]
-    entry: bash -c "docker-compose run --no-TTY sonar-scanner-cloud"
-    language: system


### PR DESCRIPTION
* Github workflow configuration for running sonar-scanner
* Remove sonar-scanner step from pre-push git hook
  * Since we have the sonar-scanner step working in Github actions,
this will be removed. It is better to remove this from running locally
since we want to only really run analysis in the CI pipeline (ideally,
at least by draft pull request phase).