### PR TITLE
Fix: Disable CSRF for test client app

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -6,6 +6,8 @@ from backend.models import Users
 @pytest.fixture(scope="module")
 def test_client():
     flask_app = create_app()
+    flask_app.config["TESTING"] = True
+    flask_app.config["WTF_CSRF_METHODS"] = []
 
     with flask_app.test_client() as testing_client:
         with flask_app.app_context():


### PR DESCRIPTION
If CSRF isn't disabled in the test client app, the unit tests will fail.