### PR TITLE
Protect routes for adding/deleting posts with jwt + update unit tests

### DIFF
--- a/backend/backend/add_post/routes.py
+++ b/backend/backend/add_post/routes.py
@@ -1,12 +1,14 @@
+from . import add_post_blueprint
+from backend.utils import add_post as utils_add_post
 from flask import (
     jsonify,
     request,
 )
-from . import add_post_blueprint
-from backend.utils import add_post as utils_add_post
+from flask_jwt_extended import jwt_required
 
 
 @add_post_blueprint.route("/api/add_post", methods=["POST"])
+@jwt_required()
 def add_post():
     json_mimetype = {"Content-Type": "application/json"}
 

--- a/backend/backend/delete_post/routes.py
+++ b/backend/backend/delete_post/routes.py
@@ -1,12 +1,14 @@
+from . import delete_post_blueprint
+from backend.utils import delete_post as utils_delete_post
 from flask import (
     jsonify,
     request,
 )
-from . import delete_post_blueprint
-from backend.utils import delete_post as utils_delete_post
+from flask_jwt_extended import jwt_required
 
 
 @delete_post_blueprint.route("/api/delete_post", methods=["DELETE"])
+@jwt_required()
 def delete_post():
     json_mimetype = {"Content-Type": "application/json"}
 

--- a/backend/backend/get_posts/routes.py
+++ b/backend/backend/get_posts/routes.py
@@ -1,6 +1,6 @@
-from flask import jsonify
 from . import get_posts_blueprint
 from backend.utils import get_posts as utils_get_posts
+from flask import jsonify
 
 
 @get_posts_blueprint.route("/api/posts", methods=["GET"])

--- a/backend/tests/test_delete_post_routes.py
+++ b/backend/tests/test_delete_post_routes.py
@@ -1,4 +1,5 @@
 import pytest
+from flask_jwt_extended import create_access_token
 
 
 class TestDeletePostEndpointDelete:
@@ -8,6 +9,21 @@ class TestDeletePostEndpointDelete:
         self.mocker = mocker
         self.test_client = test_client
         self.init_db = init_database
+
+        jwt_token = create_access_token("test-user")
+        self.header = {"Authorization": f"Bearer {jwt_token}"}
+
+    def test_no_jwt_token_raises_auth_error(self):
+        delete_json = {"post_id": 1}
+
+        response = self.test_client.delete(
+            self.endpoint,
+            content_type="application/json",
+            json=delete_json,
+        )
+
+        assert response.status_code == 401
+        assert b"Missing Authorization Header" in response.data
 
     def test_bad_data_raises_exception(self):
         delete_json = {"unexpected": "data"}
@@ -20,6 +36,7 @@ class TestDeletePostEndpointDelete:
             self.endpoint,
             content_type="application/json",
             json=delete_json,
+            headers=self.header,
         )
 
         assert response.status_code == 400
@@ -33,6 +50,7 @@ class TestDeletePostEndpointDelete:
             self.endpoint,
             content_type="application/json",
             json=delete_json,
+            headers=self.header,
         )
 
         assert response.status_code == 200


### PR DESCRIPTION
* Add jwt protection for the add_post and delete_post routes
* Update unit tests to account for jwt handling
* Add unit tests to verify unauthorized response from no jwt token