### PR TITLE
Add functionality for JWT token refresh + Jest tests + pytest tests

### DIFF
--- a/backend/backend/__init__.py
+++ b/backend/backend/__init__.py
@@ -37,6 +37,7 @@ def register_blueprints(app):
     from backend.delete_post import delete_post_blueprint
     from backend.get_posts import get_posts_blueprint
     from backend.login import login_blueprint
+    from backend.refresh_token import refresh_token_blueprint
     from backend.register import register_blueprint
     from backend.users import users_blueprint
 
@@ -55,5 +56,6 @@ def register_blueprints(app):
     app.register_blueprint(delete_post_blueprint)
     app.register_blueprint(get_posts_blueprint)
     app.register_blueprint(login_blueprint)
+    app.register_blueprint(refresh_token_blueprint)
     app.register_blueprint(register_blueprint)
     app.register_blueprint(users_blueprint)

--- a/backend/backend/__init__.py
+++ b/backend/backend/__init__.py
@@ -33,6 +33,7 @@ def create_app():
 
 def register_blueprints(app):
     from backend.add_post import add_post_blueprint
+    from backend.check_token_expiration import token_expiration_blueprint
     from backend.delete_post import delete_post_blueprint
     from backend.get_posts import get_posts_blueprint
     from backend.login import login_blueprint
@@ -50,6 +51,7 @@ def register_blueprints(app):
     csrf.exempt(users_blueprint)
 
     app.register_blueprint(add_post_blueprint)
+    app.register_blueprint(token_expiration_blueprint)
     app.register_blueprint(delete_post_blueprint)
     app.register_blueprint(get_posts_blueprint)
     app.register_blueprint(login_blueprint)

--- a/backend/backend/__init__.py
+++ b/backend/backend/__init__.py
@@ -38,6 +38,7 @@ def register_blueprints(app):
     from backend.get_posts import get_posts_blueprint
     from backend.login import login_blueprint
     from backend.logout_access import logout_access_blueprint
+    from backend.logout_refresh import logout_refresh_blueprint
     from backend.refresh_token import refresh_token_blueprint
     from backend.register import register_blueprint
     from backend.users import users_blueprint
@@ -58,6 +59,7 @@ def register_blueprints(app):
     app.register_blueprint(get_posts_blueprint)
     app.register_blueprint(login_blueprint)
     app.register_blueprint(logout_access_blueprint)
+    app.register_blueprint(logout_refresh_blueprint)
     app.register_blueprint(refresh_token_blueprint)
     app.register_blueprint(register_blueprint)
     app.register_blueprint(users_blueprint)

--- a/backend/backend/__init__.py
+++ b/backend/backend/__init__.py
@@ -37,6 +37,7 @@ def register_blueprints(app):
     from backend.delete_post import delete_post_blueprint
     from backend.get_posts import get_posts_blueprint
     from backend.login import login_blueprint
+    from backend.logout_access import logout_access_blueprint
     from backend.refresh_token import refresh_token_blueprint
     from backend.register import register_blueprint
     from backend.users import users_blueprint
@@ -56,6 +57,7 @@ def register_blueprints(app):
     app.register_blueprint(delete_post_blueprint)
     app.register_blueprint(get_posts_blueprint)
     app.register_blueprint(login_blueprint)
+    app.register_blueprint(logout_access_blueprint)
     app.register_blueprint(refresh_token_blueprint)
     app.register_blueprint(register_blueprint)
     app.register_blueprint(users_blueprint)

--- a/backend/backend/__init__.py
+++ b/backend/backend/__init__.py
@@ -33,7 +33,6 @@ def create_app():
 
 def register_blueprints(app):
     from backend.add_post import add_post_blueprint
-    from backend.check_token_expiration import token_expiration_blueprint
     from backend.delete_post import delete_post_blueprint
     from backend.get_posts import get_posts_blueprint
     from backend.login import login_blueprint
@@ -41,6 +40,7 @@ def register_blueprints(app):
     from backend.logout_refresh import logout_refresh_blueprint
     from backend.refresh_token import refresh_token_blueprint
     from backend.register import register_blueprint
+    from backend.token_expiration import token_expiration_blueprint
     from backend.users import users_blueprint
 
     # TODO: Add CSRF protection for routes

--- a/backend/backend/login/routes.py
+++ b/backend/backend/login/routes.py
@@ -4,7 +4,10 @@ from flask import (
     jsonify,
     request,
 )
-from flask_jwt_extended import create_access_token
+from flask_jwt_extended import (
+    create_access_token,
+    create_refresh_token,
+)
 
 
 @login_blueprint.route("/api/login", methods=["POST"])
@@ -24,7 +27,12 @@ def login():
 
             if len(user) == 1:
                 jwt_token = create_access_token(identity=user[0]["id"])
-                return (jsonify({"token": jwt_token}), 200, json_mimetype)
+                refresh_token = create_refresh_token(identity=user[0]["id"])
+                return (
+                    jsonify({"token": jwt_token, "refreshToken": refresh_token}),
+                    200,
+                    json_mimetype,
+                )
 
         return (jsonify({"error": "Invalid credentials"}), 200, json_mimetype)
 

--- a/backend/backend/logout_access/__init__.py
+++ b/backend/backend/logout_access/__init__.py
@@ -1,0 +1,7 @@
+from flask import Blueprint
+
+
+logout_access_blueprint = Blueprint("logout_access", __name__)
+
+# We want to ignore "imported but unused" and "module level import not at top of file" since these are necessary for accessing routes from the blueprint
+from . import routes  # noqa: F401,E402

--- a/backend/backend/logout_access/routes.py
+++ b/backend/backend/logout_access/routes.py
@@ -3,7 +3,7 @@ from ..models import InvalidToken
 from flask import jsonify
 
 from flask_jwt_extended import (
-    get_raw_jwt,
+    get_jwt,
     jwt_required,
 )
 
@@ -12,7 +12,7 @@ from flask_jwt_extended import (
 @jwt_required()
 def logout_access():
     json_mimetype = {"Content-Type": "application/json"}
-    jti = get_raw_jwt()["jti"]
+    jti = get_jwt()["jti"]
 
     try:
         invalid_token = InvalidToken(jti=jti)

--- a/backend/backend/logout_access/routes.py
+++ b/backend/backend/logout_access/routes.py
@@ -1,0 +1,24 @@
+from . import logout_access_blueprint
+from ..models import InvalidToken
+from flask import jsonify
+
+from flask_jwt_extended import (
+    get_raw_jwt,
+    jwt_required,
+)
+
+
+@logout_access_blueprint.route("/api/logout/access", methods=["POST"])
+@jwt_required
+def logout_access():
+    json_mimetype = {"Content-Type": "application/json"}
+    jti = get_raw_jwt()["jti"]
+
+    try:
+        invalid_token = InvalidToken(jti=jti)
+        invalid_token.save()
+
+        return (jsonify({"success": True}), 200, json_mimetype)
+
+    except Exception as err:
+        return (jsonify({"error": str(err)}), 400, json_mimetype)

--- a/backend/backend/logout_refresh/__init__.py
+++ b/backend/backend/logout_refresh/__init__.py
@@ -1,0 +1,7 @@
+from flask import Blueprint
+
+
+logout_refresh_blueprint = Blueprint("logout_refresh", __name__)
+
+# We want to ignore "imported but unused" and "module level import not at top of file" since these are necessary for accessing routes from the blueprint
+from . import routes  # noqa: F401,E402

--- a/backend/backend/logout_refresh/routes.py
+++ b/backend/backend/logout_refresh/routes.py
@@ -3,7 +3,7 @@ from ..models import InvalidToken
 from flask import jsonify
 
 from flask_jwt_extended import (
-    get_raw_jwt,
+    get_jwt,
     jwt_required,
 )
 
@@ -12,7 +12,7 @@ from flask_jwt_extended import (
 @jwt_required()
 def logout_refresh():
     json_mimetype = {"Content-Type": "application/json"}
-    jti = get_raw_jwt()["jti"]
+    jti = get_jwt()["jti"]
 
     try:
         invalid_token = InvalidToken(jti=jti)

--- a/backend/backend/logout_refresh/routes.py
+++ b/backend/backend/logout_refresh/routes.py
@@ -1,4 +1,4 @@
-from . import logout_access_blueprint
+from . import logout_refresh_blueprint
 from ..models import InvalidToken
 from flask import jsonify
 
@@ -8,9 +8,9 @@ from flask_jwt_extended import (
 )
 
 
-@logout_access_blueprint.route("/api/logout/access", methods=["POST"])
+@logout_refresh_blueprint.route("/api/logout/refresh", methods=["POST"])
 @jwt_required()
-def logout_access():
+def logout_refresh():
     json_mimetype = {"Content-Type": "application/json"}
     jti = get_raw_jwt()["jti"]
 

--- a/backend/backend/models.py
+++ b/backend/backend/models.py
@@ -19,3 +19,18 @@ class Post(db.Model):
     user = db.relationship("User", foreign_keys=uid)
     title = db.Column(db.String(256))
     content = db.Column(db.String(2048))
+
+
+class InvalidToken(db.Model):
+    __tablename__ = "invalid_tokens"
+    id = db.Column(db.Integer, primary_key=True)
+    jti = db.Column(db.String)
+
+    def save(self):
+        db.session.add(self)
+        db.session.commit()
+
+    @classmethod
+    def is_invalid(cls, jti):
+        q = cls.query.filter_by(jti=jti).first()
+        return bool(q)

--- a/backend/backend/refresh_token/__init__.py
+++ b/backend/backend/refresh_token/__init__.py
@@ -1,0 +1,7 @@
+from flask import Blueprint
+
+
+refresh_token_blueprint = Blueprint("refresh_token", __name__)
+
+# We want to ignore "imported but unused" and "module level import not at top of file" since these are necessary for accessing routes from the blueprint
+from . import routes  # noqa: F401,E402

--- a/backend/backend/refresh_token/routes.py
+++ b/backend/backend/refresh_token/routes.py
@@ -4,12 +4,12 @@ from flask import jsonify
 from flask_jwt_extended import (
     create_access_token,
     get_jwt_identity,
-    jwt_refresh_token_required,
+    jwt_required,
 )
 
 
 @refresh_token_blueprint.route("/api/refresh_token", methods=["POST"])
-@jwt_refresh_token_required
+@jwt_required(refresh=True)
 def refresh_token():
     json_mimetype = {"Content-Type": "application/json"}
     identity = get_jwt_identity()

--- a/backend/backend/refresh_token/routes.py
+++ b/backend/backend/refresh_token/routes.py
@@ -1,0 +1,18 @@
+from . import refresh_token_blueprint
+from flask import jsonify
+
+from flask_jwt_extended import (
+    create_access_token,
+    get_jwt_identity,
+    jwt_refresh_token_required,
+)
+
+
+@refresh_token_blueprint.route("/api/refresh_token", methods=["POST"])
+@jwt_refresh_token_required
+def refresh_token():
+    json_mimetype = {"Content-Type": "application/json"}
+    identity = get_jwt_identity()
+    token = create_access_token(identity=identity)
+
+    return (jsonify({"token": token}), 200, json_mimetype)

--- a/backend/backend/token_expiration/__init__.py
+++ b/backend/backend/token_expiration/__init__.py
@@ -1,0 +1,7 @@
+from flask import Blueprint
+
+
+token_expiration_blueprint = Blueprint("token_expiration", __name__)
+
+# We want to ignore "imported but unused" and "module level import not at top of file" since these are necessary for accessing routes from the blueprint
+from . import routes  # noqa: F401,E402

--- a/backend/backend/token_expiration/routes.py
+++ b/backend/backend/token_expiration/routes.py
@@ -8,7 +8,7 @@ from flask_jwt_extended import (
 
 
 @token_expiration_blueprint.route("/api/token_expiration", methods=["POST"])
-@jwt_required
+@jwt_required()
 def token_expiration():
     json_mimetype = {"Content-Type": "application/json"}
     print(get_jwt_identity())

--- a/backend/backend/token_expiration/routes.py
+++ b/backend/backend/token_expiration/routes.py
@@ -1,0 +1,16 @@
+from . import token_expiration_blueprint
+from flask import jsonify
+
+from flask_jwt_extended import (
+    get_jwt_identity,
+    jwt_required,
+)
+
+
+@token_expiration_blueprint.route("/api/token_expiration", methods=["POST"])
+@jwt_required
+def token_expiration():
+    json_mimetype = {"Content-Type": "application/json"}
+    print(get_jwt_identity())
+
+    return (jsonify({"success": True}), 200, json_mimetype)

--- a/backend/backend/utils.py
+++ b/backend/backend/utils.py
@@ -1,5 +1,9 @@
-from backend import db
+from backend import (
+    db,
+    jwt,
+)
 from backend.models import (
+    InvalidToken,
     Post,
     User,
 )
@@ -124,3 +128,10 @@ def remove_user(uid: str) -> bool:
             raise
 
     return False
+
+
+# ----- JWT Token utility functions ----- #
+@jwt.token_in_blacklist_loader
+def check_if_blacklisted_token(decrypted):
+    jti = decrypted["jti"]
+    return InvalidToken.is_invalid(jti)

--- a/backend/backend/utils.py
+++ b/backend/backend/utils.py
@@ -131,7 +131,7 @@ def remove_user(uid: str) -> bool:
 
 
 # ----- JWT Token utility functions ----- #
-@jwt.token_in_blacklist_loader
-def check_if_blacklisted_token(decrypted):
+@jwt.token_in_blocklist_loader
+def check_if_blocklisted_token(decrypted):
     jti = decrypted["jti"]
     return InvalidToken.is_invalid(jti)

--- a/backend/backend/utils.py
+++ b/backend/backend/utils.py
@@ -132,6 +132,6 @@ def remove_user(uid: str) -> bool:
 
 # ----- JWT Token utility functions ----- #
 @jwt.token_in_blocklist_loader
-def check_if_blocklisted_token(decrypted):
+def check_if_blocklisted_token(jwt_header, decrypted: dict):
     jti = decrypted["jti"]
     return InvalidToken.is_invalid(jti)

--- a/backend/tests/test_logout_access.py
+++ b/backend/tests/test_logout_access.py
@@ -3,7 +3,7 @@ from flask_jwt_extended import create_access_token
 from sqlalchemy.exc import SQLAlchemyError
 
 
-class TestLogoutRefreshEndpointPost:
+class TestLogoutAccessEndpointPost:
     @pytest.fixture(autouse=True)
     def __inject_fixtures(self, mocker, test_client):
         self.endpoint = "/api/logout/access"

--- a/backend/tests/test_logout_access.py
+++ b/backend/tests/test_logout_access.py
@@ -1,0 +1,40 @@
+import pytest
+from flask_jwt_extended import create_access_token
+from sqlalchemy.exc import SQLAlchemyError
+
+
+class TestLogoutRefreshEndpointPost:
+    @pytest.fixture(autouse=True)
+    def __inject_fixtures(self, mocker, test_client):
+        self.endpoint = "/api/logout/access"
+        self.mocker = mocker
+        self.test_client = test_client
+
+    def test_bad_data_raises_exception(self):
+        mock_model = self.mocker.patch("backend.logout_access.routes.InvalidToken.save")
+        mock_model.side_effect = SQLAlchemyError("Forced testing SQLAlchemyError")
+        access_token = create_access_token("jwt_token")
+        headers = {"Authorization": f"Bearer {access_token}"}
+
+        response = self.test_client.post(
+            self.endpoint,
+            content_type="application/json",
+            headers=headers,
+        )
+
+        assert response.status_code == 400
+        assert b"error" in response.data
+
+    def test_returns_success(self):
+        self.mocker.patch("backend.logout_access.routes.InvalidToken")
+        access_token = create_access_token("jwt_token")
+        headers = {"Authorization": f"Bearer {access_token}"}
+
+        response = self.test_client.post(
+            self.endpoint,
+            content_type="application/json",
+            headers=headers,
+        )
+
+        assert response.status_code == 200
+        assert b"success" in response.data

--- a/backend/tests/test_logout_access.py
+++ b/backend/tests/test_logout_access.py
@@ -26,7 +26,6 @@ class TestLogoutRefreshEndpointPost:
         assert b"error" in response.data
 
     def test_returns_success(self):
-        self.mocker.patch("backend.logout_access.routes.InvalidToken")
         access_token = create_access_token("jwt_token")
         headers = {"Authorization": f"Bearer {access_token}"}
 

--- a/backend/tests/test_logout_refresh.py
+++ b/backend/tests/test_logout_refresh.py
@@ -3,7 +3,7 @@ from flask_jwt_extended import create_access_token
 from sqlalchemy.exc import SQLAlchemyError
 
 
-class TestLogoutAccessEndpointPost:
+class TestLogoutRefreshEndpointPost:
     @pytest.fixture(autouse=True)
     def __inject_fixtures(self, mocker, test_client):
         self.endpoint = "/api/logout/refresh"

--- a/backend/tests/test_logout_refresh.py
+++ b/backend/tests/test_logout_refresh.py
@@ -28,7 +28,6 @@ class TestLogoutAccessEndpointPost:
         assert b"error" in response.data
 
     def test_returns_success(self):
-        self.mocker.patch("backend.logout_refresh.routes.InvalidToken")
         access_token = create_access_token("jwt_token")
         headers = {"Authorization": f"Bearer {access_token}"}
 

--- a/backend/tests/test_logout_refresh.py
+++ b/backend/tests/test_logout_refresh.py
@@ -1,0 +1,42 @@
+import pytest
+from flask_jwt_extended import create_access_token
+from sqlalchemy.exc import SQLAlchemyError
+
+
+class TestLogoutAccessEndpointPost:
+    @pytest.fixture(autouse=True)
+    def __inject_fixtures(self, mocker, test_client):
+        self.endpoint = "/api/logout/refresh"
+        self.mocker = mocker
+        self.test_client = test_client
+
+    def test_bad_data_raises_exception(self):
+        mock_model = self.mocker.patch(
+            "backend.logout_refresh.routes.InvalidToken.save"
+        )
+        mock_model.side_effect = SQLAlchemyError("Forced testing SQLAlchemyError")
+        access_token = create_access_token("jwt_token")
+        headers = {"Authorization": f"Bearer {access_token}"}
+
+        response = self.test_client.post(
+            self.endpoint,
+            content_type="application/json",
+            headers=headers,
+        )
+
+        assert response.status_code == 400
+        assert b"error" in response.data
+
+    def test_returns_success(self):
+        self.mocker.patch("backend.logout_refresh.routes.InvalidToken")
+        access_token = create_access_token("jwt_token")
+        headers = {"Authorization": f"Bearer {access_token}"}
+
+        response = self.test_client.post(
+            self.endpoint,
+            content_type="application/json",
+            headers=headers,
+        )
+
+        assert response.status_code == 200
+        assert b"success" in response.data

--- a/backend/tests/test_refresh_token.py
+++ b/backend/tests/test_refresh_token.py
@@ -1,0 +1,24 @@
+import pytest
+from flask_jwt_extended import create_refresh_token
+
+
+class TestRefreshTokenEndpointPost:
+    @pytest.fixture(autouse=True)
+    def __inject_fixtures(self, mocker, test_client):
+        self.endpoint = "/api/refresh_token"
+        self.test_client = test_client
+
+    def test_returns_success(self):
+        access_token = create_refresh_token("jwt_token")
+        headers = {"Authorization": f"Bearer {access_token}"}
+        post_json = {"token": access_token}
+
+        response = self.test_client.post(
+            self.endpoint,
+            content_type="application/json",
+            headers=headers,
+            json=post_json,
+        )
+
+        assert response.status_code == 200
+        assert b"token" in response.data

--- a/backend/tests/test_token_expiration.py
+++ b/backend/tests/test_token_expiration.py
@@ -1,0 +1,22 @@
+import pytest
+from flask_jwt_extended import create_access_token
+
+
+class TestTokenExpirationEndpointPost:
+    @pytest.fixture(autouse=True)
+    def __inject_fixtures(self, mocker, test_client):
+        self.endpoint = "/api/token_expiration"
+        self.test_client = test_client
+
+    def test_returns_success(self):
+        access_token = create_access_token("jwt_token")
+        headers = {"Authorization": f"Bearer {access_token}"}
+
+        response = self.test_client.post(
+            self.endpoint,
+            content_type="application/json",
+            headers=headers,
+        )
+
+        assert response.status_code == 200
+        assert b"success" in response.data

--- a/frontend/src/components/App.jsx
+++ b/frontend/src/components/App.jsx
@@ -1,22 +1,28 @@
 // src/components/App.jsx
-import React from 'react'
 import Home from './Home'
+import Login from './Login'
+import Logout from './Logout'
 import MainPage from './MainPage'
 import Navbar from './Navbar'
-import Login from './Login'
+import React from 'react'
 import Register from './Register'
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom'
 import { checkToken } from '../utils/login'
 
 function App () {
+  const [login, setLogin] = React.useState(false)
+
+  checkToken().then(response => setLogin(response))
+
   return (
         <React.Fragment>
             <Navbar />
             <Router>
                 <Routes>
-                        <Route path="/" exact element={ checkToken() ? <MainPage /> : <Home />} />
+                        <Route path="/" exact element={ login ? <MainPage /> : <Home />} />
                         <Route path="/login" exact element={<Login />} />
                         <Route path="/register" exact element={<Register />} />
+                        <Route path="/logout" exact element={<Logout />} />
                 </Routes>
             </Router>
         </React.Fragment>

--- a/frontend/src/components/Login.jsx
+++ b/frontend/src/components/Login.jsx
@@ -1,10 +1,18 @@
 // src/components/Login.jsx
 import { Component } from 'react'
 import Alert from './Alert'
-import { login } from '../utils/login'
+import { login, checkToken } from '../utils/login'
 
 class Login extends Component {
   state = { err: '' }
+
+  componentDidMount () {
+    checkToken().then(response => {
+      if (response) {
+        window.location = '/'
+      }
+    })
+  }
 
   login = (e) => {
     e.preventDefault()
@@ -13,7 +21,6 @@ class Login extends Component {
       document.getElementById('password').value)
       .then((res) => {
         if (res === true) {
-          this.setState({ login: true })
           window.location = '/'
         } else {
           this.setState({ err: res })
@@ -52,14 +59,11 @@ class Login extends Component {
                                 data-testid="test-password"
                             />
                         </p>
-                        <div style={{ marginBottom: '1rem' }}>
+                        <p>
                             <button type="submit" className="w3-button w3-blue" data-testid="test-submit-button">
                                 Login
                             </button>
-                            <div data-testid="test-success-msg">
-                              {this.state.login && 'You\'re logged in!'}
-                            </div>
-                        </div>
+                        </p>
                     </form>
                 </div>
             </div>

--- a/frontend/src/components/Logout.jsx
+++ b/frontend/src/components/Logout.jsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import { logout } from '../utils/login'
+
+class Logout extends React.component {
+  componentDidMount () {
+    logout()
+  }
+
+  render () {
+    return (
+      <div className="w3-container w3-xlarge">
+        <p>Please wait, logging you out...</p>
+      </div>
+    )
+  }
+}
+
+export default Logout

--- a/frontend/src/components/Logout.jsx
+++ b/frontend/src/components/Logout.jsx
@@ -8,7 +8,9 @@ class Logout extends React.Component {
 
   render () {
     return (
-      <div className="w3-container w3-xlarge">
+      <div
+        className="w3-container w3-xlarge"
+        data-testid="test-logout-message">
         <p>Please wait, logging you out...</p>
       </div>
     )

--- a/frontend/src/components/Logout.jsx
+++ b/frontend/src/components/Logout.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { logout } from '../utils/login'
 
-class Logout extends React.component {
+class Logout extends React.Component {
   componentDidMount () {
     logout()
   }

--- a/frontend/src/components/__tests__/App.test.jsx
+++ b/frontend/src/components/__tests__/App.test.jsx
@@ -1,35 +1,90 @@
-import { render, screen } from '@testing-library/react'
+import { act, render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
+import axios from 'axios'
 import App from '../App'
 
-test('App should render App fragment component correctly for Home page', async () => {
-  render(<App />)
+describe('User interacts with Login component', () => {
+  // When logging in, there will be two axios calls
+  // to check for token expiration and to log in
+  // Each one will have a different response, respectively
 
-  expect(await screen.getByTestId('test-navbar')).toBeInTheDocument()
+  beforeEach(() => {
+    jest.clearAllMocks()
+    localStorage.clear()
+  })
 
-  const allLinks = await screen.getAllByRole('link')
-  expect(allLinks[0]).toHaveAttribute('href', '/')
-  expect(allLinks[1]).toHaveAttribute('href', '/login')
-  expect(allLinks[2]).toHaveAttribute('href', '/register')
+  test('App should render App fragment component correctly for Home page', async () => {
+    jest.mock('axios')
+    axios.post = jest.fn()
+    axios.post.mockResolvedValueOnce({
+      error: 'Call to /api/token_expiration has failed. Test causes an error.'
+    })
 
-  // The Home page component is rendered
-  expect(await screen.getByTestId('test-login-button')).toBeInTheDocument()
-  expect(await screen.getByTestId('test-register-button')).toBeInTheDocument()
-  expect(await screen.getByTestId('test-post')).toBeInTheDocument()
-})
+    await act(async () => { render(<App />) })
 
-test('App should render App fragment component correctly for Main page', async () => {
-  localStorage.setItem('token', 'test-token')
-  render(<App />)
+    expect(await screen.getByTestId('test-navbar')).toBeInTheDocument()
 
-  expect(await screen.getByTestId('test-navbar')).toBeInTheDocument()
+    const allLinks = await screen.getAllByRole('link')
+    expect(allLinks[0]).toHaveAttribute('href', '/')
+    expect(allLinks[1]).toHaveAttribute('href', '/login')
+    expect(allLinks[2]).toHaveAttribute('href', '/register')
 
-  const allLinks = await screen.getAllByRole('link')
-  expect(allLinks[0]).toHaveAttribute('href', '/')
-  expect(allLinks[1]).toHaveAttribute('href', '/login')
-  expect(allLinks[2]).toHaveAttribute('href', '/register')
+    // The Home page component is rendered
+    expect(await screen.getByTestId('test-login-button')).toBeInTheDocument()
+    expect(await screen.getByTestId('test-register-button')).toBeInTheDocument()
+    expect(await screen.getByTestId('test-post')).toBeInTheDocument()
+  })
 
-  // The Main page component is rendered
-  expect(await screen.getByTestId('test-main-posts')).toBeInTheDocument()
-  expect(await screen.getByTestId('test-posts-list')).toBeInTheDocument()
+  test('App should render App fragment component correctly for Main page', async () => {
+    jest.mock('axios')
+    axios.post = jest.fn()
+    axios.post.mockImplementation((url) => {
+      switch (url) {
+        case '/api/token_expiration':
+          return {
+            data: {
+              success: true
+            }
+          }
+        case '/api/refresh_token':
+          return {
+            data: {
+              token: 'my-refresh-token'
+            }
+          }
+        default:
+          return {
+            error: 'An error has occurred with your test'
+          }
+      }
+    })
+    axios.get = jest.fn()
+    axios.get.mockResolvedValueOnce(
+      {
+        data: [
+          {
+            id: '1',
+            title: 'test title',
+            content: 'test content',
+            user: '1'
+          }
+        ]
+      }
+    )
+
+    const mockToken = 'my-stored-token'
+    localStorage.setItem('token', mockToken)
+    await act(async () => { render(<App />) })
+
+    expect(await screen.getByTestId('test-navbar')).toBeInTheDocument()
+
+    const allLinks = await screen.getAllByRole('link')
+    expect(allLinks[0]).toHaveAttribute('href', '/')
+    expect(allLinks[1]).toHaveAttribute('href', '/login')
+    expect(allLinks[2]).toHaveAttribute('href', '/register')
+
+    // The Main page component is rendered
+    expect(await screen.getByTestId('test-main-posts')).toBeInTheDocument()
+    expect(await screen.getByTestId('test-posts-list')).toBeInTheDocument()
+  })
 })

--- a/frontend/src/components/__tests__/Login.test.jsx
+++ b/frontend/src/components/__tests__/Login.test.jsx
@@ -22,14 +22,6 @@ describe('User interacts with Login component', () => {
     localStorage.clear()
   })
 
-  test('Login should render Login form component correctly', async () => {
-    render(<Login />)
-
-    expect(await screen.getByTestId('test-email')).toBeInTheDocument()
-    expect(await screen.getByTestId('test-password')).toBeInTheDocument()
-    expect(await screen.getByTestId('test-submit-button')).toBeInTheDocument()
-  })
-
   test('User logs in with valid credentials', async () => {
     jest.mock('axios')
     axios.post = jest.fn().mockResolvedValue({

--- a/frontend/src/components/__tests__/Logout.test.jsx
+++ b/frontend/src/components/__tests__/Logout.test.jsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import Logout from '../Logout'
+
+test('Logout should render Logout form component correctly', async () => {
+  render(<Logout />)
+
+  expect(await screen.getByTestId('test-logout-message')).toBeInTheDocument()
+})

--- a/frontend/src/components/__tests__/Logout.test.jsx
+++ b/frontend/src/components/__tests__/Logout.test.jsx
@@ -1,9 +1,62 @@
 import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import Logout from '../Logout'
+import axios from 'axios'
 
-test('Logout should render Logout form component correctly', async () => {
-  render(<Logout />)
+jest.useFakeTimers()
 
-  expect(await screen.getByTestId('test-logout-message')).toBeInTheDocument()
+describe('User interacts with Logout component', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    localStorage.clear()
+    delete window.location
+  })
+
+  test('Logout should render Logout form component correctly', async () => {
+    render(<Logout />)
+
+    expect(await screen.getByTestId('test-logout-message')).toBeInTheDocument()
+  })
+
+  test('User logs out clears access and refresh tokens', async () => {
+    jest.mock('axios')
+    axios.post = jest.fn().mockResolvedValue({
+      data: {
+        success: 'success!'
+      }
+    })
+
+    const mockAccessToken = 'my-access-token'
+    localStorage.setItem('token', mockAccessToken)
+
+    const mockRefreshToken = 'my-refresh-token'
+    localStorage.setItem('refreshToken', mockRefreshToken)
+
+    render(<Logout />)
+    jest.advanceTimersByTime(500)
+
+    expect(await screen.getByTestId('test-logout-message')).toBeInTheDocument()
+    expect(window.location).toBe('/')
+    expect(axios.post).toHaveBeenCalledTimes(2)
+    expect(axios.post).toHaveBeenNthCalledWith(
+      1,
+      '/api/logout/access',
+      {},
+      {
+        headers: {
+          Authorization: `Bearer ${mockAccessToken}`
+        }
+      }
+    )
+    expect(axios.post).toHaveBeenNthCalledWith(
+      2,
+      '/api/logout/refresh',
+      {},
+      {
+        headers: {
+          Authorization: `Bearer ${mockRefreshToken}`
+        }
+      }
+    )
+  })
 })

--- a/frontend/src/components/__tests__/Logout.test.jsx
+++ b/frontend/src/components/__tests__/Logout.test.jsx
@@ -12,7 +12,7 @@ describe('User interacts with Logout component', () => {
     delete window.location
   })
 
-  test('Logout should render Logout form component correctly', async () => {
+  test('Logout should render Logout form component correctly with no tokens in localStorage', async () => {
     render(<Logout />)
 
     expect(await screen.getByTestId('test-logout-message')).toBeInTheDocument()

--- a/frontend/src/components/__tests__/Logout.test.jsx
+++ b/frontend/src/components/__tests__/Logout.test.jsx
@@ -59,4 +59,46 @@ describe('User interacts with Logout component', () => {
       }
     )
   })
+
+  test('User logs out with invalid access and refresh tokens returned', async () => {
+    jest.mock('axios')
+    axios.post = jest.fn().mockResolvedValue({
+      data: {
+        error: 'error clearing tokens!'
+      }
+    })
+
+    const mockAccessToken = 'invalid-access-token'
+    localStorage.setItem('token', mockAccessToken)
+
+    const mockRefreshToken = 'invalid-refresh-token'
+    localStorage.setItem('refreshToken', mockRefreshToken)
+
+    render(<Logout />)
+    jest.advanceTimersByTime(500)
+
+    expect(await screen.getByTestId('test-logout-message')).toBeInTheDocument()
+    expect(window.location).toBe('/')
+    expect(axios.post).toHaveBeenCalledTimes(2)
+    expect(axios.post).toHaveBeenNthCalledWith(
+      1,
+      '/api/logout/access',
+      {},
+      {
+        headers: {
+          Authorization: `Bearer ${mockAccessToken}`
+        }
+      }
+    )
+    expect(axios.post).toHaveBeenNthCalledWith(
+      2,
+      '/api/logout/refresh',
+      {},
+      {
+        headers: {
+          Authorization: `Bearer ${mockRefreshToken}`
+        }
+      }
+    )
+  })
 })

--- a/frontend/src/utils/login.js
+++ b/frontend/src/utils/login.js
@@ -47,4 +47,41 @@ async function checkToken () {
   }
 }
 
-export { login, checkToken }
+function logout () {
+  if (localStorage.getItem('token')) {
+    const token = localStorage.getItem('token')
+
+    axios.post('/api/logout/access', {}, {
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    }).then(response => {
+      if (response.data.error) {
+        console.error(response.data.error)
+      } else {
+        localStorage.removeItem('token')
+      }
+    })
+  }
+
+  if (localStorage.getItem('refreshToken')) {
+    const refreshToken = localStorage.getItem('refreshToken')
+
+    axios.post('/api/logout/refresh', {}, {
+      header: {
+        Authorization: `Bearer ${refreshToken}`
+      }
+    }).then(response => {
+      if (response.data.error) {
+        console.error(response.data.error)
+      } else {
+        localStorage.removeItem('refreshToken')
+      }
+    })
+  }
+
+  localStorage.clear()
+  setTimeout(() => { window.location = '/' }, 500)
+}
+
+export { login, checkToken, logout }

--- a/frontend/src/utils/login.js
+++ b/frontend/src/utils/login.js
@@ -68,7 +68,7 @@ function logout () {
     const refreshToken = localStorage.getItem('refreshToken')
 
     axios.post('/api/logout/refresh', {}, {
-      header: {
+      headers: {
         Authorization: `Bearer ${refreshToken}`
       }
     }).then(response => {

--- a/frontend/src/utils/login.js
+++ b/frontend/src/utils/login.js
@@ -27,7 +27,6 @@ async function checkToken () {
     const { data } = await response
     return data.success
   } catch {
-    console.log('p')
     const refreshToken = localStorage.getItem('refreshToken')
 
     if (!refreshToken) {

--- a/frontend/src/utils/login.js
+++ b/frontend/src/utils/login.js
@@ -9,12 +9,42 @@ async function login (email, pwd) {
     return data.error
   } else {
     localStorage.setItem('token', data.token)
+    localStorage.setItem('refreshToken', data.refreshToken)
     return true
   }
 }
 
-function checkToken () {
-  return localStorage.getItem('token')
+async function checkToken () {
+  const token = localStorage.getItem('token')
+
+  try {
+    const response = await axios.post('/api/token_expiration', {}, {
+      headers: {
+        Authorization: `Bearer ${token}`
+      }
+    })
+
+    const { data } = await response
+    return data.success
+  } catch {
+    console.log('p')
+    const refreshToken = localStorage.getItem('refreshToken')
+
+    if (!refreshToken) {
+      localStorage.removeItem('token')
+      return false
+    }
+
+    axios.post('/api/refresh_token', {}, {
+      headers: {
+        Authorization: `Bearer ${refreshToken}`
+      }
+    }).then(response => {
+      localStorage.setItem('token', response.data.token)
+    })
+
+    return true
+  }
 }
 
 export { login, checkToken }

--- a/frontend/src/utils/login.js
+++ b/frontend/src/utils/login.js
@@ -57,7 +57,7 @@ function logout () {
       }
     }).then(response => {
       if (response.data.error) {
-        console.error(response.data.error)
+        console.log(response.data.error)
       } else {
         localStorage.removeItem('token')
       }
@@ -73,7 +73,7 @@ function logout () {
       }
     }).then(response => {
       if (response.data.error) {
-        console.error(response.data.error)
+        console.log(response.data.error)
       } else {
         localStorage.removeItem('refreshToken')
       }


### PR DESCRIPTION
This is a large change which enhances JWT with token refreshes.
* New token handling routes created in Flask
* New calls from frontend to routes for handling JWT access and refresh tokens when user logs in and out
* Add/update Jest and pytest tests to cover JWT token handling